### PR TITLE
add external image URI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ _For more example and a playground please refer to [storybook](https://todilo.gi
 | notifyOnPointerUp         | function                     | not set | Pass your own function that takes x, y as arguments . Will be called when mouse or touch is released.                            | -                                            |
 | notifyOnPointerMoved      | function                     | not set | Pass your own function that takes x, y as arguments . Will be called any time the mouse or touch is moved if being pressed down. |                                              |
 
+
 <!-- ROADMAP -->
 
 ## Roadmap

--- a/src/components/React360Viewer/React360Viewer.tsx
+++ b/src/components/React360Viewer/React360Viewer.tsx
@@ -14,6 +14,7 @@ export type ZeroPadRange = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 export interface React360ViewerProps {
   imagesCount: number;
   imagesBaseUrl: string;
+  imageIndexSeparator?: string;
   imagesFiletype: string;
   imageFilenamePrefix: string;
   imageInitialIndex?: number;
@@ -135,16 +136,23 @@ export const React360Viewer = ({
 
   useEffect(() => {
     function createImageSources() {
-      let baseUrl = imagesBaseUrl.endsWith("/")
-        ? imagesBaseUrl
-        : imagesBaseUrl + "/";
+
+      let baseUrl;
+
+      if (imageIndexSeparator !== undefined) {
+        baseUrl = imagesBaseUrl + imageIndexSeparator;
+      } else {
+        baseUrl = imagesBaseUrl.endsWith("/")
+          ? imagesBaseUrl
+          : imagesBaseUrl + "/";
+      };
+
       let srces = [];
       let fileType = imagesFiletype.replace(".", "");
       for (let i = 1; i <= imagesCount; i++) {
         srces.push({
-          src: `${baseUrl}${imageFilenamePrefix ? imageFilenamePrefix : ""}${
-            !!zeroPad ? String(i).padStart(zeroPad + 1, "0") : i
-          }.${fileType}`,
+          src: `${baseUrl}${imageFilenamePrefix ? imageFilenamePrefix : ""}${!!zeroPad ? String(i).padStart(zeroPad + 1, "0") : i
+            }.${fileType}`,
           index: i.toString(),
         });
       }
@@ -237,8 +245,8 @@ export const React360Viewer = ({
       onPointerDown={onMouseDown}
       // onPointerUp={onMouseUp}
       onPointerMove={onMouseMove}
-      // onMouseDown={onMouseDown}
-      // onMouseMove={onMouseMove}
+    // onMouseDown={onMouseDown}
+    // onMouseMove={onMouseMove}
     >
       {showRotationIcon ? (
         <StyledRotateIcon widthInEm={2} isReverse={reverse}></StyledRotateIcon>

--- a/src/components/React360Viewer/React360Viewer.tsx
+++ b/src/components/React360Viewer/React360Viewer.tsx
@@ -61,6 +61,7 @@ const StyledDiv = styled.div<StyleProps>`
 export const React360Viewer = ({
   imagesCount,
   imagesBaseUrl,
+  imageIndexSeparator,
   imagesFiletype,
   imageFilenamePrefix,
   mouseDragSpeed = 20,


### PR DESCRIPTION
prop imageIndexSeparator is added to allow more flexibility when using external image URIs and image CDNs. Default behaviour of the library is maintained and this prop should be as option to be used if the use necessitates it.